### PR TITLE
Analytic tvcov

### DIFF
--- a/src/Pumas.jl
+++ b/src/Pumas.jl
@@ -4,7 +4,6 @@ using DiffEqBase, DiffEqDiffTools, Reexport, StatsBase,
       StaticArrays, DiffEqJump, Distributed, LabelledArrays, GLM,
       TreeViews, CSV, ForwardDiff, DiffResults, Optim, PDMats,
       Missings, RecipesBase, StructArrays, RecursiveArrayTools, HCubature
-using DataInterpolations
 using  AdvancedHMC, MCMCChains
 
 import DataInterpolations

--- a/src/Pumas.jl
+++ b/src/Pumas.jl
@@ -4,6 +4,7 @@ using DiffEqBase, DiffEqDiffTools, Reexport, StatsBase,
       StaticArrays, DiffEqJump, Distributed, LabelledArrays, GLM,
       TreeViews, CSV, ForwardDiff, DiffResults, Optim, PDMats,
       Missings, RecipesBase, StructArrays, RecursiveArrayTools, HCubature
+using DataInterpolations
 using  AdvancedHMC, MCMCChains
 
 import DataInterpolations

--- a/src/analytical_solutions/standard_models.jl
+++ b/src/analytical_solutions/standard_models.jl
@@ -27,7 +27,7 @@ function (::OneCompartmentModel)(t,t0,amounts,doses,p,rates)
   return LabelledArrays.SLVector(Depot=Depot, Central=Central)
 end
 Base.@pure varnames(::Type{OneCompartmentModel}) = (:Depot, :Central)
-Base.@pure paramnames(::Type{ImmediateAbsorptionModel}) = (:Ka,:CL,:V)
+Base.@pure paramnames(::Type{OneCompartmentModel}) = (:Ka,:CL,:V)
 pk_init(::OneCompartmentModel) = SLVector(Depot=0.0,Central=0.0)
 
 struct OneCompartmentParallelModel <: ExplicitModel end
@@ -52,5 +52,5 @@ function (::OneCompartmentParallelModel)(t,t0,amounts,doses,p,rates)
   LabelledArrays.SLVector(Depot1=Depot1, Depot2=Depot2, Central=Central)
 end
 Base.@pure varnames(::Type{OneCompartmentParallelModel}) = (:Depot1, :Depot2, :Central)
-Base.@pure paramnames(::Type{ImmediateAbsorptionModel}) = (:Ka1,:Ka2,:CL,:V)
+Base.@pure paramnames(::Type{OneCompartmentParallelModel}) = (:Ka1,:Ka2,:CL,:V)
 pk_init(::OneCompartmentParallelModel) = SLVector(Depot1=0.0,Depot2=0.0,Central=0.0)

--- a/src/analytical_solutions/standard_models.jl
+++ b/src/analytical_solutions/standard_models.jl
@@ -9,7 +9,8 @@ function (::ImmediateAbsorptionModel)(t,t0,C0,dose,p,rate)
   rKe = rate/Ke
   rKe + exp(-(t-t0)*Ke) * (-rKe + C0)
 end
-varnames(::Type{ImmediateAbsorptionModel}) = [:Central]
+Base.@pure varnames(::Type{ImmediateAbsorptionModel}) = (:Central,)
+Base.@pure paramnames(::Type{ImmediateAbsorptionModel}) = (:CL,:V)
 pk_init(::ImmediateAbsorptionModel) = SLVector(Central=0.0)
 
 struct OneCompartmentModel <: ExplicitModel end
@@ -23,13 +24,11 @@ function (::OneCompartmentModel)(t,t0,amounts,doses,p,rates)
   Depot  = (amt[1] * Sa) + (1-Sa)*rates[1]/(Ka)          # next depot (cmt==1)
   Central =  Ka / (Ka - Ke) * (amt[1] * (Se - Sa) + rates[1]*((1-Se)/Ke - (1-Sa)/Ka)) +
     amt[2] * Se + (1-Se)*rates[2]/Ke # next central (cmt==2)
-
   return LabelledArrays.SLVector(Depot=Depot, Central=Central)
 end
-varnames(::Type{OneCompartmentModel}) = [:Depot, :Central]
+Base.@pure varnames(::Type{OneCompartmentModel}) = (:Depot, :Central)
+Base.@pure paramnames(::Type{ImmediateAbsorptionModel}) = (:Ka,:CL,:V)
 pk_init(::OneCompartmentModel) = SLVector(Depot=0.0,Central=0.0)
-
-OneCompartmentParallelVector = @SLVector (:Depot1, :Depot2, :Central)
 
 struct OneCompartmentParallelModel <: ExplicitModel end
 function (::OneCompartmentParallelModel)(t,t0,amounts,doses,p,rates)
@@ -50,8 +49,8 @@ function (::OneCompartmentParallelModel)(t,t0,amounts,doses,p,rates)
   Central =  ka1 / (ka1 - ke) * (amt[1] * (Se - Sa1) + rates[1]*((1-Se)/ke - (1-Sa1)/ka1)) +
   ka2 / (ka2 - ke) * (amt[2] * (Se - Sa2) + rates[2]*((1-Se)/ke - (1-Sa2)/ka2)) +
   amt[3] * Se + rates[3]/ke*(1-Se) # next central (cmt==3)
-  OneCompartmentParallelVector(Depot1,Depot2,Central)
+  LabelledArrays.SLVector(Depot1=Depot1, Depot2=Depot2, Central=Central)
 end
+Base.@pure varnames(::Type{OneCompartmentParallelModel}) = (:Depot1, :Depot2, :Central)
+Base.@pure paramnames(::Type{ImmediateAbsorptionModel}) = (:Ka1,:Ka2,:CL,:V)
 pk_init(::OneCompartmentParallelModel) = SLVector(Depot1=0.0,Depot2=0.0,Central=0.0)
-
-varnames(::Type{OneCompartmentParallelModel}) = [:Depot1, :Depot2, :Central]

--- a/src/simulate_methods/analytical.jl
+++ b/src/simulate_methods/analytical.jl
@@ -218,7 +218,7 @@ function applydose(f,t,t0,u0,dose,pnum,ptv,rate)
   if isempty(ptv)
     return f(t,t0,u0,dose,pnum,rate)
   else
-    if !all(x ->x isa ZeroSpline && x.dir = :left,ptv)
+    if !all(x ->x isa ZeroSpline && x.dir == :left,ptv)
       error("Analytical solutions only support Number and ZeroSpline (with dir = :left) parameters.")
     end
     tchange = findall(p->p.t=>t0 && p.t<=t,ptv)

--- a/src/simulate_methods/analytical.jl
+++ b/src/simulate_methods/analytical.jl
@@ -196,17 +196,12 @@ function create_ss_off_rate_vector(ss_rate,ss_cmt,rate)
   end
 end
 
-@generated function get_param_subset(col,f)
-  parnames = paramnames(f)
-  Expr(:tuple,(:($(parnames[i]) = col[$(parnames[i])]) for i in 1:length(parnames))...)
-end
-
 @generated function split_tvcov(col,f)
   parnames = paramnames(f)
   I = findall(i->col.parameters[2].parameters[i] <: Number,1:length(parnames))
-  J = I ∩ 1:length(parnames)
-  numberpars = Expr(:tuple,(:($(parnames[i]) = col[$(parnames[i])]) for i in I)...)
-  tvpars = Expr(:tuple,(:($(parnames[i]) = col[$(parnames[i])]) for i in J)...)
+  J = setdiff(I,1:length(parnames))
+  numberpars = Expr(:tuple,(:($(parnames[i]) = col.$(parnames[i])) for i in I)...)
+  tvpars = Expr(:tuple,(:($(parnames[i]) = col.$(parnames[i])) for i in J)...)
   quote
     numberpars = $numberpars
     tvpars = $tvpars

--- a/test/core/time_varying_covar.jl
+++ b/test/core/time_varying_covar.jl
@@ -127,7 +127,7 @@ m_tv_analytical = @model begin
   @covariates wt
 
   @pre begin
-      _wt = ZeroSpline(wt,t)
+      _wt = @tvcov wt t
       Ka = θ[1]
       CL = t -> θ[2] * ((_wt(t)/70)^0.75) * θ[4] * exp(η[1])
       V  = θ[3] * exp(η[2])

--- a/test/core/time_varying_covar.jl
+++ b/test/core/time_varying_covar.jl
@@ -113,7 +113,7 @@ tv_subject = Subject(evs = DosageRegimen([10, 20], ii = 24, addl = 2, time = [0,
                   cvs = (wt=[70,75,80,85,90,92,70,80],),
                   time = 0:15:(15*7))
 
-m_tv = @model begin
+m_tv_analytical = @model begin
   @param begin
       θ ∈ VectorDomain(4, lower=zeros(4), init=ones(4))
       Ω ∈ PSDDomain(2)
@@ -127,7 +127,7 @@ m_tv = @model begin
   @covariates wt
 
   @pre begin
-      _wt = @tvcov wt t
+      _wt = ZeroSpline(wt,t)
       Ka = θ[1]
       CL = t -> θ[2] * ((_wt(t)/70)^0.75) * θ[4] * exp(η[1])
       V  = θ[3] * exp(η[2])
@@ -145,9 +145,13 @@ m_tv = @model begin
   end
 end
 
-obs_analytical = simobs(m_tv,tv_subject,param,(η=[0.0,0.0]))
+param = (θ = [2.268,74.17,468.6,0.5876],
+         Ω = [0.05 0.0;
+              0.0  0.2],
+         σ = 0.1)
+obs_analytical = simobs(m_tv_analytical,tv_subject,param,(η=[0.0,0.0]))
 
-m_tv = @model begin
+m_tv_ode = @model begin
     @param begin
         θ ∈ VectorDomain(4, lower=zeros(4), init=ones(4))
         Ω ∈ PSDDomain(2)
@@ -182,4 +186,4 @@ m_tv = @model begin
     end
 end
 
-obs_numerical = simobs(m_tv,tv_subject,param,(η=[0.0,0.0]))
+obs_numerical = simobs(m_tv_ode,tv_subject,param,(η=[0.0,0.0]))


### PR DESCRIPTION
This route currently dead-ends because `p` in the post solution interpolation is constant. While we could online interpolate, for fixing post solution we'd want to have non-constant `p` anyways, so these will be the building blocks to a new form that expands `times` and iterates over the discontinuity points just as another set of time points.