### PR TITLE
Better type inference and compile time with `x === missing`

### DIFF
--- a/src/nca/auc.jl
+++ b/src/nca/auc.jl
@@ -126,7 +126,7 @@ function _auc(nca::NCASubject{C,TT,T,tEltype,AUC,AUMC,D,Z,F,N,I,P,ID,G,V,R}, int
   _tlast = tlast(nca)
   # type assert `auc`
   auc::ret_typ = zero(ret_typ)
-  if ismissing(_clast)
+  if _clast === missing
     if all(x->x<=nca.llq, conc)
       auc = zero(auc)
       cacheauc(nca, auc, interval, method, isauc)
@@ -180,7 +180,7 @@ function _auc(nca::NCASubject{C,TT,T,tEltype,AUC,AUMC,D,Z,F,N,I,P,ID,G,V,R}, int
     time0 = zero(time[idx1])
     if time[idx1] > time0
       c0′ = c0(nca, true)
-      ismissing(c0′) && throw(ArgumentError("AUC calculation cannot proceed, because `c0` gives missing"))
+      c0′ === missing && throw(ArgumentError("AUC calculation cannot proceed, because `c0` gives missing"))
       auc_0 = intervalauc(c0′, conc[idx1], time0, time[idx1], idx1-1, maxidx(nca), method, linear, log, ret_typ)
       if nca.auc_0 isa AbstractArray
         nca.auc_0[1] = auc_0
@@ -293,7 +293,7 @@ Alias for `auctau(subj; auctype=:last, interval=(zero(τ), τ))`.
 """
 function auctau(nca::NCASubject; kwargs...)
   τ = tau(nca; kwargs...)
-  ismissing(τ) && return missing
+  τ === missing && return missing
   return auc(nca; auctype=:last, interval=(zero(τ), τ), kwargs...)
 end
 
@@ -304,7 +304,7 @@ Alias for `aumctau(subj; auctype=:last, interval=(zero(τ), τ))`.
 """
 function aumctau(nca::NCASubject; kwargs...)
   τ = tau(nca; kwargs...)
-  ismissing(τ) && return missing
+  τ === missing && return missing
   return aumc(nca; auctype=:last, interval=(zero(τ), τ), kwargs...)
 end
 

--- a/src/nca/data_parsing.jl
+++ b/src/nca/data_parsing.jl
@@ -113,7 +113,7 @@ function ___read_nca(df; id=:id, time=:time, conc=:conc, occasion=:occasion,
     # the time array for the i-th subject
     subjtime = @view(times[idx])
     if hasdose
-      dose_idx = findall(x->!ismissing(x) && x > zero(x), @view amts[idx])
+      dose_idx = findall(x->x !== missing && x > zero(x), @view amts[idx])
       length(dose_idx) > 1 && occasion === nothing && error("`occasion` must be provided for multiple dosing data")
       # We want to use time instead of an integer index here, because later we
       # need to remove BLQ and missing data, so that an index number will no

--- a/src/nca/interpolate.jl
+++ b/src/nca/interpolate.jl
@@ -1,12 +1,12 @@
 function interpextrapconc(nca::NCASubject, timeout; concorigin=nothing, method=nothing, kwargs...)
-  ismissing(timeout) && return missing
+  timeout === missing && return missing
   nca.dose isa Union{NCADose, Nothing} || throw(ArgumentError("interpextrapconc doesn't support multidose data"))
   conc, time = nca.conc, nca.time
   _tlast = tlast(nca)
   isempty(timeout) && throw(ArgumentError("timeout must be a vector with at least one element"))
   out = timeout isa AbstractArray ? fill!(similar(conc, length(timeout)), zero(eltype(conc))) : zero(eltype(conc))
   for i in eachindex(out)
-    if ismissing(out[i])
+    if out[i] === missing
       _out = missing
     elseif timeout[i] <= _tlast
       _out = interpolateconc(nca, timeout[i]; method=method, concorigin=concorigin, kwargs...)

--- a/src/nca/simple.jl
+++ b/src/nca/simple.jl
@@ -454,7 +454,7 @@ end
 function swing(nca::NCASubject; usetau=false, kwargs...)
   _cmin = usetau ? ctau(nca) : cminss(nca)
   sw = (cmaxss(nca) - _cmin) ./ _cmin
-  (ismissing(sw) || isinf(sw)) ? missing : sw
+  (sw === missing || isinf(sw)) ? missing : sw
 end
 
 """

--- a/src/nca/type.jl
+++ b/src/nca/type.jl
@@ -97,17 +97,17 @@ function NCASubject(conc, time;
   time isa AbstractRange && (time = collect(time))
   conc isa AbstractRange && (conc = collect(conc))
   if concu !== true
-    conc = map(x -> ismissing(x) ? x : x*concu, conc)
+    conc = map(x -> x === missing ? x : x*concu, conc)
   end
   if timeu !== true
     if time !== nothing
-      time = map(x -> ismissing(x) ? x : x*timeu, time)
+      time = map(x -> x === missing ? x : x*timeu, time)
     end
     if start_time !== nothing
-      start_time = map(x -> ismissing(x) ? x : x*timeu, start_time)
+      start_time = map(x -> x === missing ? x : x*timeu, start_time)
     end
     if end_time !== nothing
-      end_time = map(x -> ismissing(x) ? x : x*timeu, end_time)
+      end_time = map(x -> x === missing ? x : x*timeu, end_time)
     end
   end
   multidose = T <: AbstractArray && length(dose) > 1
@@ -271,9 +271,9 @@ function Base.show(io::IO, ::MIME"text/plain", pop::NCAPopulation)
   showunits(io, first(pop), 4)
 end
 
-ismultidose(nca::NCASubject) = ismultidose(typeof(nca))
-ismultidose(nca::NCAPopulation) = ismultidose(eltype(nca.subjects))
-function ismultidose(::Type{NCASubject{C,TT,T,tEltype,AUC,AUMC,D,Z,F,N,I,P,ID,G,V,R}}) where {C,TT,T,tEltype,AUC,AUMC,D,Z,F,N,I,P,ID,G,V,R}
+Base.@pure ismultidose(nca::NCASubject) = ismultidose(typeof(nca))
+Base.@pure ismultidose(nca::NCAPopulation) = ismultidose(eltype(nca.subjects))
+Base.@pure function ismultidose(::Type{NCASubject{C,TT,T,tEltype,AUC,AUMC,D,Z,F,N,I,P,ID,G,V,R}}) where {C,TT,T,tEltype,AUC,AUMC,D,Z,F,N,I,P,ID,G,V,R}
   return D <: AbstractArray
 end
 
@@ -472,7 +472,7 @@ function Base.convert(::Type{Markdown.MD}, report::NCAReport)
   for entry in report.values
     _name = string(names(entry)[1])
     name = replace(_name, "_"=>"\\_") # escape underscore
-    ismissing(entry[end]) && (@printf(_io, "| %s | %s |\n", name, "missing"); continue)
+    entry[end] === missing && (@printf(_io, "| %s | %s |\n", name, "missing"); continue)
     for v in entry[end]
       val =  v isa Number ? round(ustrip(v), digits=2)*oneunit(v) :
              v


### PR DESCRIPTION
With `ismissing`:
```julia
julia> @code_warntype NCA.auc_extrap_percent(iv_nca_sd[1])
Variables
  #self#::Core.Compiler.Const(Pumas.NCA.auc_extrap_percent, false)
  nca::NCASubject{Array{Quantity{Float64,𝐌*𝐋^-3,Unitful.FreeUnits{(mg, L^-1),𝐌*𝐋^-3,nothing}},1},Array{Quantity{Float64,𝐓,Unitful.FreeUnits{(hr,),𝐓,nothing}},1},Array{Quantity{Float64,𝐓,Unitful.FreeUnits{(hr,),𝐓,nothing}},1},Quantity{Float64,𝐓,Unitful.FreeUnits{(hr,),𝐓,nothing}},Quantity{Float64,𝐌*𝐓*𝐋^-3,Unitful.FreeUnits{(mg, hr, L^-1),𝐌*𝐓*𝐋^-3,nothing}},Quantity{Float64,𝐌*𝐓^2*𝐋^-3,Unitful.FreeUnits{(mg, hr^2, L^-1),𝐌*𝐓^2*𝐋^-3,nothing}},NCADose{Quantity{Float64,𝐓,Unitful.FreeUnits{(hr,),𝐓,nothing}},Quantity{Float64,𝐌,Unitful.FreeUnits{(mg,),𝐌,nothing}}},Quantity{Float64,𝐓^-1,Unitful.FreeUnits{(hr^-1,),𝐓^-1,nothing}},Float64,Quantity{Float64,𝐌*𝐋^-3,Unitful.FreeUnits{(mg, L^-1),𝐌*𝐋^-3,nothing}},Int64,Int64,String,Nothing,Nothing,Nothing}

Body::Any
1 ─ %1 = Core.NamedTuple()::Core.Compiler.Const(NamedTuple(), false)
│   %2 = Base.pairs(%1)::Core.Compiler.Const(Base.Iterators.Pairs{Union{},Union{},Tuple{},NamedTuple{(),Tuple{}}}(), false)
│   %3 = Pumas.NCA.:(#auc_extrap_percent#242)(%2, #self#, nca)::Any
└──      return %3
```

With `x === missing`:
```julia
julia> @code_warntype NCA.auc_extrap_percent(iv_nca_sd[1])
Variables
  #self#::Core.Compiler.Const(Pumas.NCA.auc_extrap_percent, false)
  nca::NCASubject{Array{Quantity{Float64,𝐌*𝐋^-3,Unitful.FreeUnits{(mg, L^-1),𝐌*𝐋^-3,nothing}},1},Array{Quantity{Float64,𝐓,Unitful.FreeUnits{(hr,),𝐓,nothing}},1},Array{Quantity{Float64,𝐓,Unitful.FreeUnits{(hr,),𝐓,nothing}},1},Quantity{Float64,𝐓,Unitful.FreeUnits{(hr,),𝐓,nothing}},Quantity{Float64,𝐌*𝐓*𝐋^-3,Unitful.FreeUnits{(mg, hr, L^-1),𝐌*𝐓*𝐋^-3,nothing}},Quantity{Float64,𝐌*𝐓^2*𝐋^-3,Unitful.FreeUnits{(mg, hr^2, L^-1),𝐌*𝐓^2*𝐋^-3,nothing}},NCADose{Quantity{Float64,𝐓,Unitful.FreeUnits{(hr,),𝐓,nothing}},Quantity{Float64,𝐌,Unitful.FreeUnits{(mg,),𝐌,nothing}}},Quantity{Float64,𝐓^-1,Unitful.FreeUnits{(hr^-1,),𝐓^-1,nothing}},Float64,Quantity{Float64,𝐌*𝐋^-3,Unitful.FreeUnits{(mg, L^-1),𝐌*𝐋^-3,nothing}},Int64,Int64,String,Nothing,Nothing,Nothing}

Body::Union{Missing, Float64}
1 ─ %1 = Core.NamedTuple()::Core.Compiler.Const(NamedTuple(), false)
│   %2 = Base.pairs(%1)::Core.Compiler.Const(Base.Iterators.Pairs{Union{},Union{},Tuple{},NamedTuple{(),Tuple{}}}(), false)
│   %3 = Pumas.NCA.:(#auc_extrap_percent#242)(%2, #self#, nca)::Union{Missing, Float64}
└──      return %3
```