### PR TITLE
lower default tolerance for estimation and use a different solver

### DIFF
--- a/src/estimation/likelihoods.jl
+++ b/src/estimation/likelihoods.jl
@@ -614,18 +614,18 @@ function marginal_nll_gradient!(g::AbstractVector,
   return g
 end
 
-function _fdrelstep(model::PumasModel, param::NamedTuple, reltol::AbstractFloat, ::Val{:forward})
+function _fdrelstep(model::PumasModel, param::NamedTuple, reltol, ::Val{:forward})
   if model.prob isa ExplicitModel
     return sqrt(eps(numtype(param)))
   else
-    return max(reltol, sqrt(eps(numtype(param))))
+    return max(norm(reltol), sqrt(eps(numtype(param))))
   end
 end
-function _fdrelstep(model::PumasModel, param::NamedTuple, reltol::AbstractFloat, ::Val{:central})
+function _fdrelstep(model::PumasModel, param::NamedTuple, reltol, ::Val{:central})
   if model.prob isa ExplicitModel
     return cbrt(eps(numtype(param)))
   else
-    return max(reltol, cbrt(eps(numtype(param))))
+    return max(norm(reltol), cbrt(eps(numtype(param))))
   end
 end
 

--- a/src/estimation/likelihoods.jl
+++ b/src/estimation/likelihoods.jl
@@ -284,7 +284,7 @@ function empirical_bayes!(vrandeffs::AbstractVector,
                           approx::Union{FOCE,FOCEI,Laplace,LaplaceI},
                           args...;
                           # We explicitly use reltol to compute the right step size for finite difference based gradient
-                          reltol=DEFAULT_RELTOL,
+                          reltol=DEFAULT_ESTIMATION_RELTOL,
                           fdtype=Val{:central}(),
                           fdrelstep=_fdrelstep(m, param, reltol, fdtype),
                           kwargs...)
@@ -543,7 +543,7 @@ function marginal_nll_gradient!(g::AbstractVector,
                                 trf::TransformVariables.TransformTuple,
                                 args...;
                                 # We explicitly use reltol to compute the right step size for finite difference based gradient
-                                reltol=DEFAULT_RELTOL,
+                                reltol=DEFAULT_ESTIMATION_RELTOL,
                                 fdtype=Val{:central}(),
                                 fdrelstep=_fdrelstep(model, param, reltol, fdtype),
                                 fdabsstep=fdrelstep^2,
@@ -641,7 +641,7 @@ function marginal_nll_gradient!(g::AbstractVector,
                                 trf::TransformVariables.TransformTuple,
                                 args...;
                                 # We explicitly use reltol to compute the right step size for finite difference based gradient
-                                reltol=DEFAULT_RELTOL,
+                                reltol=DEFAULT_ESTIMATION_RELTOL,
                                 fdtype=Val{:central}(),
                                 fdrelstep=_fdrelstep(model, param, reltol, fdtype),
                                 fdabsstep=fdrelstep^2,
@@ -1077,7 +1077,7 @@ function _observed_information(f::FittedPumasModel,
                                args...;
                                # We explicitly use reltol to compute the right step size for finite difference based gradient
                                # The tolerance has to be stricter when computing the covariance than during estimation
-                               reltol=abs2(DEFAULT_RELTOL),
+                               reltol=abs2(DEFAULT_ESTIMATION_RELTOL),
                                kwargs...) where Score
   # Transformation the NamedTuple of parameters to a Vector
   # without applying any bounds (identity transform)

--- a/src/estimation/likelihoods.jl
+++ b/src/estimation/likelihoods.jl
@@ -1,7 +1,7 @@
 import DiffResults: DiffResult
 
-const DEFAULT_RELTOL=1e-6
-const DEFAULT_ABSTOL=1e-12
+const DEFAULT_ESTIMATION_RELTOL=1e-8
+const DEFAULT_ESTIMATION_ABSTOL=1e-12
 
 abstract type LikelihoodApproximation end
 struct NaivePooled <: LikelihoodApproximation end
@@ -73,8 +73,8 @@ function derived_dist(model::PumasModel,
                       # This is the only entry point to the ODE solver for the estimation code
                       # so we need to make sure to set default tolerances here if they haven't
                       # been set elsewhere.
-                      reltol=DEFAULT_RELTOL,
-                      abstol=DEFAULT_ABSTOL,
+                      reltol=DEFAULT_ESTIMATION_RELTOL,
+                      abstol=DEFAULT_ESTIMATION_ABSTOL,
                       kwargs...)
   rtrf = totransform(model.random(param))
   randeffs = TransformVariables.transform(rtrf, vrandeffs)
@@ -89,8 +89,9 @@ end
                               # This is the only entry point to the ODE solver for the estimation code
                               # so we need to make sure to set default tolerances here if they haven't
                               # been set elsewhere.
-                              reltol=DEFAULT_RELTOL,
-                              abstol=DEFAULT_ABSTOL,
+                              reltol=DEFAULT_ESTIMATION_RELTOL,
+                              abstol=DEFAULT_ESTIMATION_ABSTOL,
+                              alg = AutoVern7(Rodas5()),
                               kwargs...)
   # Extract a vector of the time stamps for the observations
   obstimes = subject.time

--- a/src/estimation/show.jl
+++ b/src/estimation/show.jl
@@ -8,7 +8,7 @@ function _print_fit_header(io, fpm)
   println(io, string("Likelihood approximation:",
                      lpad(typeof(fpm.approx), 19)))
   println(io, string("Objective function value:",
-                     lpad(round(Optim.minimum(fpm.optim); sigdigits=round(Int, -log10(DEFAULT_RELTOL))), 19)))
+                     lpad(round(Optim.minimum(fpm.optim); sigdigits=round(Int, -log10(DEFAULT_ESTIMATION_RELTOL))), 19)))
   println(io, string("Total number of observation records:",
                      lpad(sum([length(sub.time) for sub in fpm.data]), 8)))
   println(io, string("Number of active observation records:",

--- a/test/nlme/simple_model.jl
+++ b/test/nlme/simple_model.jl
@@ -63,7 +63,7 @@ FittedPumasModel
 Successful minimization:                true
 
 Likelihood approximation:        Pumas.FOCEI
-Objective function value:            45.6238
+Objective function value:          45.623789
 Total number of observation records:      20
 Number of active observation records:     20
 Number of subjects:                       10


### PR DESCRIPTION
Fixes https://github.com/PumasAI/Pumas.jl/issues/602 . By using a lower tolerance, the line search tends to succeed. However, with these tolerances it enters a different performance regime. In this regime, Rodas5 is stable enough and will be faster than Rosenbrock23, while Vern9 is probably the fastest non-stiff method but has higher compile times, so Vern7 is a good middle ground. 

@vjd can you test these new defaults on some examples that were failing?