### PR TITLE
Don't throw errors when try/catching in simulated obs DataFrame constructors

### DIFF
--- a/src/data_parsing/data_types.jl
+++ b/src/data_parsing/data_types.jl
@@ -337,13 +337,8 @@ function DataFrames.DataFrame(subject::Subject; include_covariates=true, include
   else
     df
   end
-  if include_covariates
-    if !isa(subject.covariates, Nothing)
-      for (covariate, value) in pairs(subject.covariates)
-        df[!,covariate] .= value
-      end
-    end
-  end
+
+  include_covariates && _add_covariates!(df, subject)
 
   # Sort the df according to time first, and use :base_time to ensure that events
   # come before observations (they are missing for observations, so they will come
@@ -372,7 +367,14 @@ function DataFrames.DataFrame(subject::Subject; include_covariates=true, include
   # Return df
   df
 end
-
+function _add_covariates!(df::DataFrame, subject::Subject)
+  covariates = subject.covariates
+  if !isa(covariates, Nothing)
+    for (covariate, value) in pairs(covariates)
+      df[!,covariate] .= value
+    end
+  end
+end
 
 ### Display
 Base.summary(::Subject) = "Subject"

--- a/src/models/simulated_observations.jl
+++ b/src/models/simulated_observations.jl
@@ -68,6 +68,8 @@ function DataFrames.DataFrame(obs::SimulatedObservations;
         end
       end
     end
+
+    df = df[df[!, :evid].!=-1,:]
     sort!(df, (:time, order(:evid, rev=event_order_reverse)))
   end
   if include_covariates


### PR DESCRIPTION
This syncs some functionality in the subject constructor. I need to look more into this, but this removes some weird errors at least.

In #649 the `DataFrame` construction threw errors (but worked). This removes those errors by allowing dv columns to be missing before looping. 

cc @vjd 

edit: oh yeah, and the original part of this pr: don't keep evid == -1 in the sim obs dataframe either.