### PR TITLE
Add diagnostics tool: findinfluential.

### DIFF
--- a/src/estimation/diagnostics.jl
+++ b/src/estimation/diagnostics.jl
@@ -574,3 +574,16 @@ end
 
     primary := false # do not add a legend entry here, do other nice things that Plots does as well
 end
+
+# This will use default args and kwargs!!
+findinfluential(fpm::FittedPumasModel) = findinfluential(fpm.model, fpm.data, fpm.param, fpm.approx)
+function findinfluential(m::PumasModel,
+                         data::Population,
+                         param::NamedTuple,
+                         approx::LikelihoodApproximation,
+                         args...;
+                         k=5, kwargs...)
+  d = [deviance(m, subject, param, approx, args...; kwargs...) for subject in data]
+  p = partialsortperm(d, 1:k, rev=true)
+  return [(data[pᵢ].id, d[pᵢ]) for pᵢ in p]
+end


### PR DESCRIPTION
Shows most influential observations as measured by their `deviance`.

Stolen and cleaned from @andreasnoack here https://github.com/PumasAI/Pumas.jl/issues/524 Added a method for FittedPumasModel - though notice we don't store `args...` and `kwargs...`, so it will just use the defaults. 

Bikeshedding of function name and keyword name (`k`, specifies how many influential points to show).

To see how it works, look at the following:
```
julia> using Pumas, LinearAlgebra

julia> theopp = read_pumas(example_nmtran_data("event_data/THEOPP"),cvs = [:SEX,:WT])
Population
  Subjects: 12
  Covariates: SEX, WT
  Observables: dv


julia> theopmodel_analytical_fo = @model begin
         @param begin
           θ₁ ∈ RealDomain(lower=0.1,    upper=5.0, init=2.77)
           θ₂ ∈ RealDomain(lower=0.0008, upper=0.5, init=0.0781)
           θ₃ ∈ RealDomain(lower=0.004,  upper=0.9, init=0.0363)
           θ₄ ∈ RealDomain(lower=0.1,    upper=5.0, init=1.5)
           Ω ∈ PSDDomain(3)
           σ_add ∈ RealDomain(lower=0.001, init=0.388)
           #σ_prop ∈ RealDomain(init=0.3)
         end

         @random begin
           η ~ MvNormal(Ω)
         end

         @pre begin
           Ka = SEX == 0 ? θ₁ + η[1] : θ₄ + η[1]
           K  = θ₂+ η[2]
           CL = θ₃*WT + η[3]
           V  = CL/K
           SC = CL/K/WT
         end

         @covariates SEX WT

         @vars begin
           conc = Central / SC
         end

         @dynamics OneCompartmentModel

         @derived begin
           dv ~ @. Normal(conc,sqrt(σ_add))
         end
       end
PumasModel
  Parameters: θ₁, θ₂, θ₃, θ₄, Ω, σ_add
  Random effects: η
  Covariates: SEX, WT
  Dynamical variables: Depot, Central
  Derived: conc, dv
  Observed: conc, dv


julia> param = (
         θ₁ = 2.77,   #Ka MEAN ABSORPTION RATE CONSTANT for SEX = 1(1/HR)
         θ₂ = 0.0781, #K MEAN ELIMINATION RATE CONSTANT (1/HR)
         θ₃ = 0.0363, #SLP  SLOPE OF CLEARANCE VS WEIGHT RELATIONSHIP (LITERS/HR/KG)
         θ₄ = 1.5,    #Ka MEAN ABSORPTION RATE CONSTANT for SEX=0 (1/HR)
         Ω  = diagm(0 => [5.55, 0.0024, 0.515]), # update to block diagonal
         σ_add = 0.388
         # σ_prop = 0.3
                   )
(θ₁ = 2.77, θ₂ = 0.0781, θ₃ = 0.0363, θ₄ = 1.5, Ω = [5.55 0.0 0.0; 0.0 0.0024 0.0; 0.0 0.0 0.515], σ_add = 0.388)

julia> o = fit(theopmodel_analytical_fo, theopp, param, Pumas.FOCEI());

julia> newdata=DataFrame(o.data)
144×14 DataFrame. Omitted printing of 7 columns
│ Row │ id     │ time    │ evid  │ dv       │ amt      │ dose    │ tad     │
│     │ String │ Float64 │ Int64 │ Float64⍰ │ Float64⍰ │ Float64 │ Float64 │
├─────┼────────┼─────────┼───────┼──────────┼──────────┼─────────┼─────────┤
│ 1   │ 1      │ 0.0     │ 1     │ missing  │ 4.02     │ 4.02    │ 0.0     │
│ 2   │ 1      │ 0.0     │ 0     │ 0.74     │ missing  │ 4.02    │ 0.0     │
│ 3   │ 1      │ 0.25    │ 0     │ 2.84     │ missing  │ 4.02    │ 0.25    │
│ 4   │ 1      │ 0.57    │ 0     │ 6.57     │ missing  │ 4.02    │ 0.57    │
│ 5   │ 1      │ 1.12    │ 0     │ 10.5     │ missing  │ 4.02    │ 1.12    │
│ 6   │ 1      │ 2.02    │ 0     │ 9.66     │ missing  │ 4.02    │ 2.02    │
│ 7   │ 1      │ 3.82    │ 0     │ 8.58     │ missing  │ 4.02    │ 3.82    │
│ 8   │ 1      │ 5.1     │ 0     │ 8.36     │ missing  │ 4.02    │ 5.1     │
│ 9   │ 1      │ 7.03    │ 0     │ 7.47     │ missing  │ 4.02    │ 7.03    │
│ 10  │ 1      │ 9.05    │ 0     │ 6.89     │ missing  │ 4.02    │ 9.05    │
│ 11  │ 1      │ 12.12   │ 0     │ 5.94     │ missing  │ 4.02    │ 12.12   │
│ 12  │ 1      │ 24.37   │ 0     │ 3.28     │ missing  │ 4.02    │ 24.37   │
│ 13  │ 2      │ 0.0     │ 1     │ missing  │ 4.4      │ 4.4     │ 0.0     │
│ 14  │ 2      │ 0.0     │ 0     │ 0.0      │ missing  │ 4.4     │ 0.0     │
│ 15  │ 2      │ 0.27    │ 0     │ 1.72     │ missing  │ 4.4     │ 0.27    │
│ 16  │ 2      │ 0.52    │ 0     │ 7.91     │ missing  │ 4.4     │ 0.52    │
│ 17  │ 2      │ 1.0     │ 0     │ 8.31     │ missing  │ 4.4     │ 1.0     │
│ 18  │ 2      │ 1.92    │ 0     │ 8.33     │ missing  │ 4.4     │ 1.92    │
│ 19  │ 2      │ 3.5     │ 0     │ 6.85     │ missing  │ 4.4     │ 3.5     │
⋮
│ 125 │ 11     │ 0.98    │ 0     │ 8.0      │ missing  │ 4.92    │ 0.98    │
│ 126 │ 11     │ 1.98    │ 0     │ 6.81     │ missing  │ 4.92    │ 1.98    │
│ 127 │ 11     │ 3.6     │ 0     │ 5.87     │ missing  │ 4.92    │ 3.6     │
│ 128 │ 11     │ 5.02    │ 0     │ 5.22     │ missing  │ 4.92    │ 5.02    │
│ 129 │ 11     │ 7.03    │ 0     │ 4.45     │ missing  │ 4.92    │ 7.03    │
│ 130 │ 11     │ 9.03    │ 0     │ 3.62     │ missing  │ 4.92    │ 9.03    │
│ 131 │ 11     │ 12.12   │ 0     │ 2.69     │ missing  │ 4.92    │ 12.12   │
│ 132 │ 11     │ 24.08   │ 0     │ 0.86     │ missing  │ 4.92    │ 24.08   │
│ 133 │ 12     │ 0.0     │ 1     │ missing  │ 5.3      │ 5.3     │ 0.0     │
│ 134 │ 12     │ 0.0     │ 0     │ 0.0      │ missing  │ 5.3     │ 0.0     │
│ 135 │ 12     │ 0.25    │ 0     │ 1.25     │ missing  │ 5.3     │ 0.25    │
│ 136 │ 12     │ 0.5     │ 0     │ 3.96     │ missing  │ 5.3     │ 0.5     │
│ 137 │ 12     │ 1.0     │ 0     │ 7.82     │ missing  │ 5.3     │ 1.0     │
│ 138 │ 12     │ 2.0     │ 0     │ 9.72     │ missing  │ 5.3     │ 2.0     │
│ 139 │ 12     │ 3.52    │ 0     │ 9.75     │ missing  │ 5.3     │ 3.52    │
│ 140 │ 12     │ 5.07    │ 0     │ 8.57     │ missing  │ 5.3     │ 5.07    │
│ 141 │ 12     │ 7.07    │ 0     │ 6.59     │ missing  │ 5.3     │ 7.07    │
│ 142 │ 12     │ 9.03    │ 0     │ 6.11     │ missing  │ 5.3     │ 9.03    │
│ 143 │ 12     │ 12.05   │ 0     │ 4.57     │ missing  │ 5.3     │ 12.05   │
│ 144 │ 12     │ 24.15   │ 0     │ 1.17     │ missing  │ 5.3     │ 24.15   │

julia> newdata[2, :dv] = 9.0
9.0

julia> onew = fit(theopmodel_analytical_fo, read_pumas(newdata; cvs=[:SEX,:WT]), param, Pumas.FOCEI());

julia> o
FittedPumasModel

Successful minimization:                true

Likelihood approximation:        Pumas.FOCEI
Objective function value:            178.576
Total number of observation records:     132
Number of active observation records:    132
Number of subjects:                       12

----------------------
          Estimate
----------------------
θ₁         1.747
θ₂         0.086385
θ₃         0.04019
θ₄         1.9825
Ω₁,₁       1.5431
Ω₂,₁       0.0032231
Ω₃,₁      -0.090793
Ω₂,₂       0.00013056
Ω₃,₂       0.0074835
Ω₃,₃       0.48081
σ_add      0.47569
----------------------


julia> onew
FittedPumasModel

Successful minimization:                true

Likelihood approximation:        Pumas.FOCEI
Objective function value:            228.619
Total number of observation records:     132
Number of active observation records:    132
Number of subjects:                       12

----------------------
          Estimate
----------------------
θ₁         1.7258
θ₂         0.084335
θ₃         0.03941
θ₄         1.7246
Ω₁,₁       0.74618
Ω₂,₁       0.0036195
Ω₃,₁      -0.020468
Ω₂,₂       0.00011154
Ω₃,₂       0.0060564
Ω₃,₃       0.40376
σ_add      1.2583
----------------------


julia> Pumas.findinfluential(o)
5-element Array{Tuple{String,Float64},1}:
 ("5", 28.14687666289427) 
 ("2", 17.228869439743505)
 ("1", 14.288149609476037)
 ("4", 11.86165312573823) 
 ("9", 11.70813490763355) 

julia> Pumas.findinfluential(onew)
5-element Array{Tuple{String,Float64},1}:
 ("1", 80.1151320043184)   
 ("5", 18.66390670376269)  
 ("9", 17.835401083163724) 
 ("2", 13.650487059952653) 
 ("12", 12.661392605142936)
 ```

What I did what to modify an observation to a nonsense value. We see that most of the parameters stay at their values which is alright, but of course some variance terms become much bigger with this point that cannot be explained. Calling `findinfluential` would help us find potential data points (subjects here) with issues. Either data issues, or behavior that our current model isn't rich enough to capture (maybe we need a covariate, blablabla).

Needs a doc string, and(?) an export.