### PR TITLE
Store args and kwargs from `fit` in order to correctly apply diagnostics tools

### DIFF
--- a/src/estimation/likelihoods.jl
+++ b/src/estimation/likelihoods.jl
@@ -1010,12 +1010,14 @@ _∂²l∂η²(nl_d::ForwardDiff.Dual,
         args...; kwargs...) = throw(ArgumentError("Distribution is current not supported for the $approx approximation. Please consider a different likelihood approximation."))
 
 # Fitting methods
-struct FittedPumasModel{T1<:PumasModel,T2<:Population,T3,T4<:LikelihoodApproximation, T5}
+struct FittedPumasModel{T1<:PumasModel,T2<:Population,T3,T4<:LikelihoodApproximation, T5, T6, T7}
   model::T1
   data::T2
   optim::T3
   approx::T4
   vvrandeffsorth::T5
+  args::T6
+  kwargs::T7
 end
 
 function DEFAULT_OPTIMIZE_FN(cost, p, callback)
@@ -1119,7 +1121,7 @@ function Distributions.fit(m::PumasModel,
     end
   end
 
-  return FittedPumasModel(m, population, o, approx, vvrandeffsorth)
+  return FittedPumasModel(m, population, o, approx, vvrandeffsorth, args, kwargs)
 end
 
 function Distributions.fit(m::PumasModel,

--- a/test/nlme/runtests.jl
+++ b/test/nlme/runtests.jl
@@ -1,6 +1,10 @@
 using Test, SafeTestsets
 using Pumas, LinearAlgebra, Optim, StatsBase
 
+if gorup == "All" || group == "NLMNE_Basic"
+  @time @safetestset "Types (constructors, api, etc...)"             begin include("types.jl")                  end
+end
+
 if group == "All" || group == "NLME_ML1"
   @time @safetestset "Maximum-likelihood models 1" begin
     @time @safetestset "Simple Model"                                begin include("simple_model.jl")              end

--- a/test/nlme/runtests.jl
+++ b/test/nlme/runtests.jl
@@ -1,7 +1,7 @@
 using Test, SafeTestsets
 using Pumas, LinearAlgebra, Optim, StatsBase
 
-if gorup == "All" || group == "NLMNE_Basic"
+if group == "All" || group == "NLMNE_Basic"
   @time @safetestset "Types (constructors, api, etc...)"             begin include("types.jl")                  end
 end
 

--- a/test/nlme/types.jl
+++ b/test/nlme/types.jl
@@ -1,0 +1,46 @@
+using Test
+using Pumas, LinearAlgebra
+
+@testset "args and kwargs" begin
+data = read_pumas(example_nmtran_data("sim_data_model1"))
+#-----------------------------------------------------------------------# Test 1
+mdsl1 = @model begin
+    @param begin
+        θ ∈ VectorDomain(1, init=[0.5])
+        Ω ∈ ConstDomain(Diagonal([0.04]))
+        Σ ∈ ConstDomain(0.1)
+    end
+
+    @random begin
+        η ~ MvNormal(Ω)
+    end
+
+    @pre begin
+        CL = θ[1] * exp(η[1])
+        V  = 1.0
+    end
+
+    @vars begin
+        conc = Central / V
+    end
+
+    @dynamics ImmediateAbsorptionModel
+
+    @derived begin
+        dv ~ @. Normal(conc,conc*sqrt(Σ)+eps())
+    end
+end
+
+param = init_param(mdsl1)
+
+ft_no_args = fit(mdsl1, data, param, Pumas.FOCEI())
+@test isempty(pairs(ft_no_args.args))
+@test isempty(pairs(ft_no_args.kwargs))
+
+ft_alg_kwargs = fit(mdsl1, data, param, Pumas.FOCEI(); alg=Rosenbrock23())
+@test isempty(pairs(ft_alg_kwargs.args))
+kwarg_pairs = pairs(ft_alg_kwargs.kwargs)
+@test keys(kwarg_pairs) == (:alg,)
+@test kwarg_pairs[1] == Rosenbrock23()
+
+end


### PR DESCRIPTION
Weighted residuals based on alternative `LikelihoodApproximation`s are currently calculated using the default solver and fitting choices. The same goes for `findinfluential`, predictions, and so on. This PR stores the `args` and `kwargs` passed into `fit` in the `FittedPumasModel`.