### PR TITLE
fixedcoef -> constantcoef

### DIFF
--- a/src/estimation/likelihoods.jl
+++ b/src/estimation/likelihoods.jl
@@ -1115,13 +1115,13 @@ function Distributions.fit(m::PumasModel,
                            # in zero. In addition, the returned object should support a opt_minimizer method
                            # that returns the optimized parameters.
                            optimize_fn = DEFAULT_OPTIMIZE_FN,
-                           fixedcoef = NamedTuple(),
+                           constantcoef = NamedTuple(),
                            kwargs...)
 
   # Compute transform object defining the transformations from NamedTuple to Vector while applying any parameter restrictions and apply the transformations
   trf = totransform(m.param)
   fixedtrf=trf
-  param, fixedtrf = _fixed_to_constanttransform(trf, param, fixedcoef)
+  param, fixedtrf = _fixed_to_constanttransform(trf, param, constantcoef)
   vparam = TransformVariables.inverse(fixedtrf, param)
 
   # We'll store the orthogonalized random effects estimate in vvrandeffsorth which allows us to carry the estimates from last

--- a/test/nlme/theophylline.jl
+++ b/test/nlme/theophylline.jl
@@ -98,8 +98,8 @@ end
 
   o = fit(theopmodel_analytical_fo, theopp, param, Pumas.FO())
 
-  ofix1 = fit(theopmodel_analytical_fo, theopp, param, Pumas.FO(); fixedcoef=(θ₁=0.4,))
-  ofix2 = fit(theopmodel_analytical_fo, theopp, param, Pumas.FO(); fixedcoef=(σ_add=0.1,))
+  ofix1 = fit(theopmodel_analytical_fo, theopp, param, Pumas.FO(); constantcoef=(θ₁=0.4,))
+  ofix2 = fit(theopmodel_analytical_fo, theopp, param, Pumas.FO(); constantcoef=(σ_add=0.1,))
 
   @test ofix1.param.θ₁ == 0.4
   @test ofix2.param.σ_add == 0.1


### PR DESCRIPTION
Fixedcoef might have been a bad choice of name in a population model context as pointed out by @andreasnoack . Constant is consistent with `ConstantDomain` and `ConstantTransformation`.