### PR TITLE
Fix `totransform`'s type instability

### DIFF
--- a/src/estimation/transforms.jl
+++ b/src/estimation/transforms.jl
@@ -237,14 +237,14 @@ end
 
 totransform(d::ConstDomain) = ConstantTransform(d.val)
 function totransform(d::RealDomain)
-  if d.lower == -Inf
-    if d.upper == Inf
+  if d.lower === -∞
+    if d.upper === ∞
       as(Real,-∞,∞)
     else
       as(Real,-∞,d.upper)
     end
   else
-    if d.upper == Inf
+    if d.upper === ∞
       as(Real,d.lower,∞)
     else
       as(Real,d.lower,d.upper)

--- a/src/models/params.jl
+++ b/src/models/params.jl
@@ -26,7 +26,7 @@ struct RealDomain{L,U,T} <: Domain
   upper::U
   init::T
 end
-RealDomain(;lower=-∞,upper=+∞,init=0.) = RealDomain(lower, upper, init)
+RealDomain(;lower=-∞,upper=∞,init=0.) = RealDomain(lower, upper, init)
 init(d::RealDomain) = d.init
 
 
@@ -44,7 +44,7 @@ end
 _vec(n, x::AbstractVector) = x
 _vec(n, x) = fill(x, n)
 
-VectorDomain(n::Int; lower=-∞,upper=+∞,init=0.0) = VectorDomain(_vec(n,lower), _vec(n,upper), _vec(n,init))
+VectorDomain(n::Int; lower=-∞,upper=∞,init=0.0) = VectorDomain(_vec(n,lower), _vec(n,upper), _vec(n,init))
 
 init(d::VectorDomain) = d.init
 

--- a/src/models/params.jl
+++ b/src/models/params.jl
@@ -17,34 +17,34 @@ end
 init(d::ConstDomain) = d.val
 
 """
-    @param x ∈ RealDomain(;lower=-Inf,upper=+Inf,init=0)
+    @param x ∈ RealDomain(;lower=-∞,upper=∞,init=0)
 
 Specifies a parameter as a real value. `lower` and `upper` are the respective bounds, `init` is the value used as the initial guess in the optimisation.
 """
-struct RealDomain{T} <: Domain
-  lower::T
-  upper::T
+struct RealDomain{L,U,T} <: Domain
+  lower::L
+  upper::U
   init::T
 end
-RealDomain(;lower=-Inf,upper=+Inf,init=0.) = RealDomain(promote(lower, upper, init)...)
+RealDomain(;lower=-∞,upper=+∞,init=0.) = RealDomain(lower, upper, init)
 init(d::RealDomain) = d.init
 
 
 """
-    @param x ∈ VectorDomain(n::Int; lower=-Inf,upper=+Inf,init=0)
+    @param x ∈ VectorDomain(n::Int; lower=-∞,upper=∞,init=0)
 
 Specifies a parameter as a real vector of length `n`. `lower` and `upper` are the respective bounds, `init` is the value used as the initial guess in the optimisation.
 """
-struct VectorDomain{L,T} <: Domain
+struct VectorDomain{L,U,T} <: Domain
   lower::L
-  upper::L
+  upper::U
   init::T
 end
 
 _vec(n, x::AbstractVector) = x
 _vec(n, x) = fill(x, n)
 
-VectorDomain(n::Int; lower=-Inf,upper=+Inf,init=0.0) = VectorDomain(promote(_vec(n,lower), _vec(n,upper))..., _vec(n,init))
+VectorDomain(n::Int; lower=-∞,upper=+∞,init=0.0) = VectorDomain(_vec(n,lower), _vec(n,upper), _vec(n,init))
 
 init(d::VectorDomain) = d.init
 
@@ -81,7 +81,7 @@ init(d::PDiagDomain) = d.init
 # domains of random variables
 function Domain(d::MvNormal)
   n = length(d)
-  VectorDomain(fill(-Inf, n), fill(Inf, n), mean(d))
+  VectorDomain(fill(-∞, n), fill(∞, n), mean(d))
 end
 Domain(d::InverseWishart) = PSDDomain(Distributions.dim(d))
 
@@ -113,10 +113,10 @@ struct Constrained{D<:Distribution,M<:Domain}
   domain::M
 end
 
-Constrained(dist::MvNormal; lower=-Inf, upper=Inf, init=0.0) =
+Constrained(dist::MvNormal; lower=-∞, upper=∞, init=0.0) =
   Constrained(dist, VectorDomain(length(dist); lower=lower, upper=upper, init=init))
 
-Constrained(dist::ContinuousUnivariateDistribution; lower=-Inf, upper=Inf, init=0.0) =
+Constrained(dist::ContinuousUnivariateDistribution; lower=-∞, upper=∞, init=0.0) =
   Constrained(dist, RealDomain(; lower=lower, upper=upper, init=init))
 
 Domain(c::Constrained) = c.domain

--- a/test/core/params.jl
+++ b/test/core/params.jl
@@ -26,7 +26,7 @@ using Pumas, TransformVariables, LinearAlgebra, Distributions
 
   @testset "Promotion" begin
     d = RealDomain(lower=0, upper=1.0)
-    @test d.lower === 0.0
+    @test d.lower === 0
     @test d.upper === 1.0
     d = VectorDomain(2,lower=[0  , 2.0], upper=[10  , 4  ], init=[2, 2])
     @test (d.lower...,) == (0.0, 2.0)


### PR DESCRIPTION
Fix #641

```julia
julia> code_warntype(Pumas.totransform, Tuple{RealDomain{Float64,Float64,typeof(Pumas.∞)}})
Variables
  #self#::Core.Compiler.Const(Pumas.totransform, false)
  d::RealDomain{Float64,Float64,TransformVariables.Infinity{true}}

Body::TransformVariables.ScaledShiftedLogistic{Float64}
1 ─ %1  = Base.getproperty(d, :lower)::Float64
│   %2  = -Pumas.∞::Core.Compiler.Const(TransformVariables.Infinity{false}(), false)
│   %3  = (%1 === %2)::Core.Compiler.Const(false, false)
└──       goto #3 if not %3
2 ─       Core.Compiler.Const(:(Base.getproperty(d, :upper)), false)
│         Core.Compiler.Const(:(%5 === Pumas.∞), false)
│         Core.Compiler.Const(:(%6), false)
│         Core.Compiler.Const(:(-Pumas.∞), false)
│         Core.Compiler.Const(:(Pumas.as(Pumas.Real, %8, Pumas.∞)), false)
│         Core.Compiler.Const(:(return %9), false)
│         Core.Compiler.Const(:(-Pumas.∞), false)
│         Core.Compiler.Const(:(Base.getproperty(d, :upper)), false)
│         Core.Compiler.Const(:(Pumas.as(Pumas.Real, %11, %12)), false)
└──       Core.Compiler.Const(:(return %13), false)
3 ┄ %15 = Base.getproperty(d, :upper)::Float64
│   %16 = (%15 === Pumas.∞)::Core.Compiler.Const(false, false)
└──       goto #5 if not %16
4 ─       Core.Compiler.Const(:(Base.getproperty(d, :lower)), false)
│         Core.Compiler.Const(:(Pumas.as(Pumas.Real, %18, Pumas.∞)), false)
└──       Core.Compiler.Const(:(return %19), false)
5 ┄ %21 = Base.getproperty(d, :lower)::Float64
│   %22 = Base.getproperty(d, :upper)::Float64
│   %23 = Pumas.as(Pumas.Real, %21, %22)::TransformVariables.ScaledShiftedLogistic{Float64}
└──       return %23

julia> code_warntype(Pumas.totransform, Tuple{RealDomain{Float64,Float64,Float64}})
Variables
  #self#::Core.Compiler.Const(Pumas.totransform, false)
  d::RealDomain{Float64,Float64,Float64}

Body::TransformVariables.ScaledShiftedLogistic{Float64}
1 ─ %1  = Base.getproperty(d, :lower)::Float64
│   %2  = -Pumas.∞::Core.Compiler.Const(TransformVariables.Infinity{false}(), false)
│   %3  = (%1 === %2)::Core.Compiler.Const(false, false)
└──       goto #3 if not %3
2 ─       Core.Compiler.Const(:(Base.getproperty(d, :upper)), false)
│         Core.Compiler.Const(:(%5 === Pumas.∞), false)
│         Core.Compiler.Const(:(%6), false)
│         Core.Compiler.Const(:(-Pumas.∞), false)
│         Core.Compiler.Const(:(Pumas.as(Pumas.Real, %8, Pumas.∞)), false)
│         Core.Compiler.Const(:(return %9), false)
│         Core.Compiler.Const(:(-Pumas.∞), false)
│         Core.Compiler.Const(:(Base.getproperty(d, :upper)), false)
│         Core.Compiler.Const(:(Pumas.as(Pumas.Real, %11, %12)), false)
└──       Core.Compiler.Const(:(return %13), false)
3 ┄ %15 = Base.getproperty(d, :upper)::Float64
│   %16 = (%15 === Pumas.∞)::Core.Compiler.Const(false, false)
└──       goto #5 if not %16
4 ─       Core.Compiler.Const(:(Base.getproperty(d, :lower)), false)
│         Core.Compiler.Const(:(Pumas.as(Pumas.Real, %18, Pumas.∞)), false)
└──       Core.Compiler.Const(:(return %19), false)
5 ┄ %21 = Base.getproperty(d, :lower)::Float64
│   %22 = Base.getproperty(d, :upper)::Float64
│   %23 = Pumas.as(Pumas.Real, %21, %22)::TransformVariables.ScaledShiftedLogistic{Float64}
└──       return %23
```