### PR TITLE
[NCA] Use constructors to create `DataFrame` and `MD`

### DIFF
--- a/src/nca/type.jl
+++ b/src/nca/type.jl
@@ -447,12 +447,14 @@ end
 
 # units go under the header
 to_dataframe(report::NCAReport) = convert(DataFrame, report)
+DataFrames.DataFrame(report::NCAReport) = to_dataframe(report)
 function Base.convert(::Type{DataFrame}, report::NCAReport)
   #report.settings[:subject] && return DataFrame(map(x->[x], report.values))
   hcat(report.values...)
 end
 
 to_markdown(report::NCAReport) = convert(Markdown.MD, report)
+Markdown.MD(report::NCAReport) = to_markdown(report)
 function Base.convert(::Type{Markdown.MD}, report::NCAReport)
   _io = IOBuffer()
   println(_io, "# Noncompartmental Analysis Report")

--- a/test/nca/multidose_tests.jl
+++ b/test/nca/multidose_tests.jl
@@ -51,7 +51,7 @@ lambdazdf = @test_nowarn NCA.lambdaz(mncapop)
 ncareport1 = NCAReport(mncapop[1])
 @test_nowarn ncareport1
 @test_skip display(NCA.to_markdown(ncareport1))
-@test_nowarn NCA.to_dataframe(ncareport1)
+@test_nowarn DataFrame(ncareport1)
 
 popncareport = NCAReport(mncapop)
 @test_skip display(NCA.to_markdown(popncareport))

--- a/test/nca/singledose_tests.jl
+++ b/test/nca/singledose_tests.jl
@@ -19,7 +19,7 @@ ncapop = @test_nowarn read_nca(data, id=:ID, time=:TIME, conc=:CObs, amt=:AMT_IV
 popncareport = NCAReport(ncapop, ithdose=1)
 @test_nowarn popncareport
 @test_skip display(NCA.to_markdown(popncareport))
-@test_nowarn NCA.to_dataframe(popncareport)
+@test_nowarn DataFrame(popncareport)
 
 lambdazdf = @test_nowarn NCA.lambdaz(ncapop)
 @test size(lambdazdf, 2) == 2


### PR DESCRIPTION
Fix #618