### PR TITLE
Reexport diagm, Diagonal, and I to avoid using LinearAlgebra in tests and examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Pumas: A Pharmaceutical Modeling and Simulation toolkit
 ## Demo: A Simple PK model
 
 ```julia
-using Pumas, Plots, LinearAlgebra
+using Pumas, Plots
 ```
 
 For reproducibility, we will set a random seed:

--- a/src/Pumas.jl
+++ b/src/Pumas.jl
@@ -5,6 +5,7 @@ using DiffEqDiffTools, Reexport, StatsBase,
       TreeViews, CSV, ForwardDiff, DiffResults, Optim, PDMats,
       Missings, RecipesBase, RecursiveArrayTools, HCubature,
       Statistics, DiffEqSensitivity
+using LinearAlgebra
 using AdvancedHMC: DiagEuclideanMetric, Hamiltonian, NUTS, Leapfrog, find_good_eps, StanHMCAdaptor, Preconditioner, NesterovDualAveraging
 import MCMCChains: Chains
 
@@ -68,5 +69,7 @@ export infer, inspect
 export vpc, vpc_obs
 export gsa
 export mean, std, var, coef
+# From LinearAlgebra
+export diagm, Diagonal, I
 
 end # module

--- a/src/estimation/transforms.jl
+++ b/src/estimation/transforms.jl
@@ -1,3 +1,4 @@
+using LinearAlgebra: Cholesky, copytri!
 import TransformVariables
 using TransformVariables: as, asℝ₊, ∞
 
@@ -126,7 +127,7 @@ function TransformVariables.transform_with(flag::TransformVariables.LogJacFlag, 
       error("not support")
     end
   end
-  (LinearAlgebra.copytri!(M, 'L')), ℓ
+  copytri!(M, 'L'), ℓ
 end
 
 TransformVariables.inverse_eltype(::VechTransform, y::PDMat{T}) where T = T

--- a/src/models/params.jl
+++ b/src/models/params.jl
@@ -1,4 +1,3 @@
-using LinearAlgebra
 export ParamSet, ConstDomain, RealDomain, VectorDomain, PSDDomain, PDiagDomain, Constrained
 
 abstract type Domain end

--- a/src/nca/NCA.jl
+++ b/src/nca/NCA.jl
@@ -4,7 +4,8 @@ using Reexport
 using GLM
 using DataFrames
 using RecipesBase
-using Pkg, Dates, Printf, LinearAlgebra
+using Pkg, Dates, Printf
+using LinearAlgebra: norm
 
 include("type.jl")
 include("data_parsing.jl")

--- a/src/simulate_methods/utils.jl
+++ b/src/simulate_methods/utils.jl
@@ -1,3 +1,5 @@
+using LinearAlgebra: Factorization
+
 _cmt_value(ev::Event, u0, var::Number, default) = var
 function _cmt_value(ev::Event, u0, var::Union{Tuple,AbstractArray},default)
   ev.cmt ∈ keys(var) ? var[ev.cmt] : default

--- a/test/core/dcp_rate.jl
+++ b/test/core/dcp_rate.jl
@@ -1,4 +1,4 @@
-using Pumas, Test, LinearAlgebra
+using Pumas, Test
 
 @testset "Testing dose control parameters" begin
 

--- a/test/core/error_handling.jl
+++ b/test/core/error_handling.jl
@@ -1,4 +1,4 @@
-using Test, Pumas, LinearAlgebra
+using Test, Pumas
 
 #Creating the dataset
 

--- a/test/core/generated_doses_tests.jl
+++ b/test/core/generated_doses_tests.jl
@@ -1,4 +1,4 @@
-using Test, LinearAlgebra
+using Test
 using Pumas
 
 # Gut dosing model

--- a/test/core/multiresponses.jl
+++ b/test/core/multiresponses.jl
@@ -1,4 +1,4 @@
-using Pumas, Test, LinearAlgebra
+using Pumas, Test
 
 
 ###############################

--- a/test/core/params.jl
+++ b/test/core/params.jl
@@ -1,5 +1,5 @@
 using Test
-using Pumas, TransformVariables, LinearAlgebra, Distributions
+using Pumas, TransformVariables, Distributions
 
 @testset "ParamSets and Domains tests" begin
   p = ParamSet((θ = VectorDomain(4, lower=zeros(4), init=ones(4)), # parameters

--- a/test/core/ss2_overlap_tests.jl
+++ b/test/core/ss2_overlap_tests.jl
@@ -1,4 +1,4 @@
-using Test, LinearAlgebra
+using Test
 using Pumas
 
 # Gut dosing model

--- a/test/core/static_array_test.jl
+++ b/test/core/static_array_test.jl
@@ -1,4 +1,4 @@
-using Pumas, Test, Random, LinearAlgebra, LabelledArrays
+using Pumas, Test, Random, LabelledArrays
 
 # Read the data# Read the data
 data = read_pumas(example_data("data1"),

--- a/test/features/measurement_tests.jl
+++ b/test/features/measurement_tests.jl
@@ -1,5 +1,5 @@
 using Pumas, Measurements, LabelledArrays
-using Random, LinearAlgebra, Test
+using Random, Test
 
 data = read_pumas(example_data("data1"), cvs = [:sex,:wt,:etn])
 subject = data[1]

--- a/test/nca/pumas_tests.jl
+++ b/test/nca/pumas_tests.jl
@@ -1,5 +1,4 @@
 using Pumas
-using LinearAlgebra
 
 choose_covariates() = (isPM = rand([1, 0]),
                        Wt = rand(55:80))

--- a/test/nlme/bayes.jl
+++ b/test/nlme/bayes.jl
@@ -1,4 +1,4 @@
-using Pumas, Test, CSV, Random, Distributions, LinearAlgebra, TransformVariables
+using Pumas, Test, CSV, Random, Distributions, TransformVariables
 
 theopp = read_pumas(example_data("event_data/THEOPP"),cvs = [:WT,:SEX])
 

--- a/test/nlme/bolus.jl
+++ b/test/nlme/bolus.jl
@@ -1,4 +1,4 @@
-using Pumas, LinearAlgebra, Test, CSV
+using Pumas, Test, CSV
 
 @testset "One compartment intravenous bolus study" begin
   #No. of subjects= 100, Dose = 100 or 250mg,DV=Plasma concentration, ug/ml

--- a/test/nlme/missings.jl
+++ b/test/nlme/missings.jl
@@ -1,4 +1,4 @@
-using Pumas, Test, LinearAlgebra
+using Pumas, Test
 
 @testset "Test with missing values" begin
 

--- a/test/nlme/runtests.jl
+++ b/test/nlme/runtests.jl
@@ -1,5 +1,5 @@
 using Test, SafeTestsets
-using Pumas, LinearAlgebra, Optim, StatsBase
+using Pumas, StatsBase
 
 if group == "All" || group == "NLME_Basic"
   @time @safetestset "Maximum-likelihood interface" begin

--- a/test/nlme/simple_model.jl
+++ b/test/nlme/simple_model.jl
@@ -1,5 +1,5 @@
 using Test
-using Pumas, LinearAlgebra
+using Pumas
 
 @testset "likelihood tests from NLME.jl" begin
 data = read_pumas(example_data("sim_data_model1"))
@@ -68,51 +68,4 @@ Number of subjects:                       10
 Σ         0.1
 ------------------
 """
-
-# Supporting outer AD optimization makes it harder to store the
-# EBEs since their type changes during AD optimization so for
-# the time being these tests are disabled.
-# ofn = function (cost,p)
-#   Optim.optimize(cost,p,BFGS(linesearch=Optim.LineSearches.BackTracking()),
-#                  Optim.Options(show_trace=false, # Print progress
-#                                store_trace=true,
-#                                extended_trace=true,
-#                                g_tol=1e-3),
-#                   autodiff=:finite)
-# end
-#
-# @test fit(mdsl1, data, init_param(mdsl1), Pumas.LaplaceI(), optimize_fn=ofn) isa Pumas.FittedPumasModel
-#
-# ofn2 = function (cost,p)
-#   Optim.optimize(cost,p,Newton(linesearch=Optim.LineSearches.BackTracking()),
-#                  Optim.Options(show_trace=false, # Print progress
-#                                store_trace=true,
-#                                extended_trace=true,
-#                                g_tol=1e-3),
-#                   autodiff=:finite)
-# end
-#
-# @test fit(mdsl1, data, init_param(mdsl1), Pumas.LaplaceI(), optimize_fn=ofn2) isa Pumas.FittedPumasModel
-#
-# ofn3 = function (cost,p)
-#   Optim.optimize(cost,p,BFGS(linesearch=Optim.LineSearches.BackTracking()),
-#                  Optim.Options(show_trace=false, # Print progress
-#                                store_trace=true,
-#                                extended_trace=true,
-#                                g_tol=1e-3),
-#                   autodiff=:forward)
-# end
-#
-# @test fit(mdsl1, data, init_param(mdsl1), Pumas.LaplaceI(), optimize_fn=ofn3) isa Pumas.FittedPumasModel
-#
-# ofn4 = function (cost,p)
-#   Optim.optimize(cost,p,Newton(linesearch=Optim.LineSearches.BackTracking()),
-#                  Optim.Options(show_trace=false, # Print progress
-#                                store_trace=true,
-#                                extended_trace=true,
-#                                g_tol=1e-3),
-#                   autodiff=:forward)
-# end
-#
-# @test fit(mdsl1, data, init_param(mdsl1), Pumas.LaplaceI(), optimize_fn=ofn4) isa Pumas.FittedPumasModel
 end# testset

--- a/test/nlme/simple_model_diagnostics.jl
+++ b/test/nlme/simple_model_diagnostics.jl
@@ -1,5 +1,5 @@
 using Test
-using Pumas, LinearAlgebra, Optim
+using Pumas
 
 data = read_pumas(example_data("sim_data_model1"))
 

--- a/test/nlme/simple_model_tdist.jl
+++ b/test/nlme/simple_model_tdist.jl
@@ -1,5 +1,5 @@
 using Test
-using Pumas, LinearAlgebra, Optim
+using Pumas
 
 data = read_pumas(example_data("sim_data_model1"))
 

--- a/test/nlme/single_subject.jl
+++ b/test/nlme/single_subject.jl
@@ -1,5 +1,5 @@
 using Test
-using Pumas, LinearAlgebra
+using Pumas
 
 @testset "Single subject" begin
 data = read_pumas(example_data("sim_data_model1"))

--- a/test/nlme/theop_nlme.jl
+++ b/test/nlme/theop_nlme.jl
@@ -1,5 +1,5 @@
 using Test
-using Pumas, LinearAlgebra
+using Pumas
 
 theopp_nlme = read_pumas(example_data("THEOPP"))
 

--- a/test/nlme/theophylline.jl
+++ b/test/nlme/theophylline.jl
@@ -1,5 +1,5 @@
 using Test
-using Pumas, LinearAlgebra
+using Pumas
 
 # FIXME! Find a nicer way to handle this
 _extract(A::Pumas.PDMats.PDMat) = A.mat

--- a/test/nlme/types.jl
+++ b/test/nlme/types.jl
@@ -1,5 +1,5 @@
 using Test
-using Pumas, LinearAlgebra
+using Pumas
 
 @testset "args and kwargs" begin
 data = read_pumas(example_data("sim_data_model1"))

--- a/test/nlme/wang.jl
+++ b/test/nlme/wang.jl
@@ -1,5 +1,5 @@
 using Test
-using Pumas, LinearAlgebra, Optim, CSV
+using Pumas, CSV
 
 @testset "Models from the Wang paper" begin
 

--- a/test/parallel/theophylline.jl
+++ b/test/parallel/theophylline.jl
@@ -1,6 +1,6 @@
 using Distributed
 addprocs(2)
-@everywhere using Pumas, LinearAlgebra
+@everywhere using Pumas
 theopp = read_pumas(example_data("event_data/THEOPP"),cvs=[:SEX,:WT])
 
 theopmodel_fo_a = @model begin


### PR DESCRIPTION
Also remove `using Optim` from tests since it's no longer used.