### PR TITLE
non-constant subject type tests and require patch

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -44,7 +44,7 @@ Unitful = "1986cc42-f94f-5a68-af5c-568840ba703d"
 
 [compat]
 DataFrames = "0.19"
-DiffEqBase = "6.3.1"
+DiffEqBase = "6.3.4"
 DiffEqDiffTools = "1"
 DiffEqSensitivity = "4.0.1"
 LabelledArrays = "0.7.1"

--- a/test/core/non_constant_types.jl
+++ b/test/core/non_constant_types.jl
@@ -4,7 +4,7 @@ data = read_pumas(example_data("data1"),
                       cvs = [:sex,:wt,:etn,:time])
 
 tmp = []
-push!(tmp, Subject(obs=data[1].observations, time=data[1].time, cvs=(sex=1, wt=[51.6], etn=1, time=data[1].covariates.time), evs=data[1].events))
+push!(tmp, Subject(obs=data[1].observations, time=data[1].time, cvs=(sex=1, wt=[51.6 for i in 1:length(data[1].covariates.time)], etn=1, time=data[1].covariates.time), evs=data[1].events))
 push!(tmp, data[2])
 new_data = identity.(tmp)
 
@@ -52,3 +52,4 @@ end
 obs = simobs(mdsl, new_data, init_param(mdsl), ensemblealg = EnsembleSerial())
 obs = simobs(mdsl, new_data, init_param(mdsl), ensemblealg = EnsembleThreads())
 obs = simobs(mdsl, new_data, init_param(mdsl), ensemblealg = EnsembleDistributed())
+obs = simobs(mdsl, new_data, init_param(mdsl), ensemblealg = EnsembleSplitThreads())

--- a/test/core/non_constant_types.jl
+++ b/test/core/non_constant_types.jl
@@ -1,0 +1,54 @@
+using Pumas
+
+data = read_pumas(example_data("data1"),
+                      cvs = [:sex,:wt,:etn,:time])
+
+tmp = []
+push!(tmp, Subject(obs=data[1].observations, time=data[1].time, cvs=(sex=1, wt=[51.6], etn=1, time=data[1].covariates.time), evs=data[1].events))
+push!(tmp, data[2])
+new_data = identity.(tmp)
+
+mdsl = @model begin
+    @param begin
+        θ ∈ VectorDomain(4, lower=zeros(4), init=ones(4))
+        Ω ∈ PSDDomain(2)
+        Σ ∈ RealDomain(lower=0.0, init=1.0)
+        a ∈ ConstDomain(0.2)
+    end
+
+    @random begin
+        η ~ MvNormal(Ω)
+    end
+
+    @covariates sex wt etn time
+
+    @pre begin
+        _wt = @tvcov wt time DataInterpolations.ZeroSpline
+        Ka = θ[1]
+        CL = t -> θ[2] * ((_wt(t)/70)^0.75) * (θ[4]^sex) * exp(η[1])
+        V  = θ[3] * exp(η[2])
+    end
+
+    @vars begin
+      conc = Central / V
+      conc2 = Central^2
+    end
+
+    @dynamics begin
+        Depot'   := -Ka*Depot # test for `:=` handling
+        Central' =  Ka*Depot - CL(t)*conc
+    end
+
+    @derived begin
+      dv ~ @. Normal(conc, conc*Σ)
+      T_max = maximum(t)
+    end
+
+    @observed begin
+      obs_cmax = maximum(dv)
+    end
+end
+
+obs = simobs(mdsl, new_data, init_param(mdsl), ensemblealg = EnsembleSerial())
+obs = simobs(mdsl, new_data, init_param(mdsl), ensemblealg = EnsembleThreads())
+obs = simobs(mdsl, new_data, init_param(mdsl), ensemblealg = EnsembleDistributed())

--- a/test/core/runtests.jl
+++ b/test/core/runtests.jl
@@ -24,6 +24,8 @@
     include("multiresponses.jl") end
 @time @safetestset "DCP Rate Handling Tests" begin
     include("dcp_rate.jl") end
+@time @safetestset "Non-Constant Subject Type Tests" begin
+     include("non_constant_types.jl") end
 @time @safetestset "Type-Stability Tests" begin
     include("stability_tests.jl") end
 @time @safetestset "StaticArray Tests" begin


### PR DESCRIPTION
Fixes #701 by requiring an upstream patch and tests the case. The issue was that different subjects had different time-varying-ness of the covariates, meaning that the Population wasn't a strictly-typed array of Subjects since the different subjects could have different types. The Ensemble interface assumed constant type output, but this cannot be the case if we return something that is strictly typed and holds the subjects. Thus it changes to use a promotion system to have the same behavior as before on the strict case but generalize it to allow non-same type outputs.