### PR TITLE
WIP: Print license at build time

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 *.jl.*.cov
 *.jl.mem
 Manifest.toml
+build.log

--- a/deps/build.jl
+++ b/deps/build.jl
@@ -1,0 +1,6 @@
+s = open("../LICENSE.md") do file
+    read(file, String)
+end
+
+println(stdout,s)
+println(stdout,"Note: Pumas is free for non-commercial use, but requires a license for commercial use. Please see the full license text above for more details.")


### PR DESCRIPTION
Essentially this would make it so that way every time someone adds or updates Pumas it'll print the license. I need to find out how to make it not go to the log there.