### PR TITLE
Remove redundant an fragile test of npde in theophylline

### DIFF
--- a/test/nlme/theophylline.jl
+++ b/test/nlme/theophylline.jl
@@ -618,12 +618,6 @@ end
     @test ebe_cov[i].η.Σ.mat[:] ≈ focei_ebes_cov[i,:] atol=1e-3
   end
 
-  Pumas.npde(
-    theopmodel_focei,
-    theopp[1],
-    param,
-    1000
-  )
   Pumas.epred(
     theopmodel_focei,
     theopp[1],


### PR DESCRIPTION
The `npde` function is tested in `simple_model_diagnostics.jl` so the test deleted here isn't needed. The test is fragile because the system defined by the model is unstable for some realizations of the random effects and `npde` is a simulation based method which will eventually hit an unstable realization.