### PR TITLE
subject from simulation keeps observed quantities

### DIFF
--- a/src/models/simulated_observations.jl
+++ b/src/models/simulated_observations.jl
@@ -14,12 +14,11 @@ end
 
 # Convert to Subject
 function Subject(simsubject::SimulatedObservations)
-  dvnames = keys(simsubject.subject.observations)
   covariates = simsubject.subject.covariates
   covartime = simsubject.subject.covartime
   subject = Subject(;
     id         = simsubject.subject.id,
-    obs        = NamedTuple{dvnames}(map(k -> simsubject.observed[k], dvnames)),
+    obs        = simsubject.observed,
     cvs        = covariates===nothing ? nothing : map(copy, covariates),
     evs        = copy(simsubject.subject.events),
     time       = copy(simsubject.times),

--- a/test/core/single_dosage_tests.jl
+++ b/test/core/single_dosage_tests.jl
@@ -68,7 +68,7 @@ m_analytic = @model begin
         V  = θ[3] * exp(η[2])
     end
 
-    @dynamics Depots1Central1 
+    @dynamics Depots1Central1
 
     @derived begin
         conc = @. Central / V
@@ -126,3 +126,7 @@ sol_diffeq = simobs(m_diffeq,data,param,ensemblealg = EnsembleSerial())
 sol_diffeq = simobs(m_diffeq,data,param,ensemblealg = EnsembleThreads())
 sol_diffeq = simobs(m_diffeq,data,param,ensemblealg = EnsembleSplitThreads())
 sol_diffeq = simobs(m_diffeq,data,param,ensemblealg = EnsembleDistributed())
+
+# Turn back into subjects
+simsubjects = Subject.(sol_diffeq)
+@test keys(simsubjects[1].observations) == (:cp,:conc,:dv)


### PR DESCRIPTION
It is really weird that it currently drops the observation series in the generated subject. The natural thing to do for a simulated dataset would be to have the simulated observations be the simulated observations.